### PR TITLE
Fix for not working speech recognition after moving app to background and foreground again

### DIFF
--- a/ExampleApp/ios/STTGoogle/AppDelegate.m
+++ b/ExampleApp/ios/STTGoogle/AppDelegate.m
@@ -11,11 +11,18 @@
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
 
+#if RCT_DEV
+#import <React/RCTDevLoadingView.h>
+#endif
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  #if RCT_DEV
+    [bridge moduleForClass:[RCTDevLoadingView class]];
+  #endif
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:@"STTGoogle"
                                             initialProperties:nil];

--- a/ExampleApp/ios/STTGoogle/Info.plist
+++ b/ExampleApp/ios/STTGoogle/Info.plist
@@ -39,6 +39,8 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Allow access to microphone to enable Speech to Text feature.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/README.md
+++ b/README.md
@@ -10,9 +10,18 @@
 
 #### iOS
 
-1. Place the module into node_mudules
-2. Add pod 'RNReactNativeGoogleStt', :path => '../node_modules/react-native-google-speech-api/ios' to the Podfile
-3. cd ios and pod install
+1. Place the module into `node_mudules`
+2. Add to the Podfile:
+
+  	```
+    pod 'RNReactNativeGoogleStt', :path => '../node_modules/react-native-google-speech-api/ios'
+  	```
+3. Run:
+
+  	```
+    cd ios
+    pod install
+  	```
 
 #### Android
 
@@ -116,4 +125,3 @@ export default class App extends Component {
   }
 }
 ```
-  

--- a/ios/AudioController.h
+++ b/ios/AudioController.h
@@ -28,7 +28,7 @@
 
 @property (nonatomic, assign, readonly) double specifiedSampleRate;
 
-- (instancetype)initWithSampleRate:(double)specifiedSampleRate;
+- (instancetype) initWithSampleRate:(double)specifiedSampleRate;
 
 - (OSStatus) recreateIOUnit;
 

--- a/ios/AudioController.h
+++ b/ios/AudioController.h
@@ -24,12 +24,25 @@
 
 @interface AudioController : NSObject
 
-+ (instancetype) sharedInstance;
-
 @property (nonatomic, weak) id<AudioControllerDelegate> delegate;
 
-- (OSStatus) prepareWithSampleRate:(double) sampleRate;
+@property (nonatomic, assign, readonly) double specifiedSampleRate;
+
+- (instancetype)initWithSampleRate:(double)specifiedSampleRate;
+
+- (OSStatus) recreateIOUnit;
+
+- (OSStatus) prepare;
+
 - (OSStatus) start;
+
 - (OSStatus) stop;
+
+@end
+
+@interface AudioController (Unavailable)
+
+- (instancetype) init NS_UNAVAILABLE;
++ (instancetype) new NS_UNAVAILABLE;
 
 @end

--- a/ios/AudioController.m
+++ b/ios/AudioController.m
@@ -27,17 +27,17 @@
 @implementation AudioController
 
 - (instancetype) initWithSampleRate:(double)specifiedSampleRate {
-    self = [super init];
+  self = [super init];
     if (self) {
-        _specifiedSampleRate = specifiedSampleRate;
+      _specifiedSampleRate = specifiedSampleRate;
     }
-    return self;
+  return self;
 }
 
 - (OSStatus) recreateIOUnit {
-    AudioComponentInstanceDispose(remoteIOUnit);
-    audioComponentInitialized = NO;
-    return [self prepare];
+  AudioComponentInstanceDispose(remoteIOUnit);
+  audioComponentInitialized = NO;
+  return [self prepare];
 }
 
 - (void) dealloc {
@@ -267,7 +267,7 @@ static OSStatus playbackCallback(void *inRefCon,
 }
 
 - (OSStatus) start {
-    return AudioOutputUnitStart(self->remoteIOUnit);
+  return AudioOutputUnitStart(self->remoteIOUnit);
 }
 
 - (OSStatus) stop {

--- a/ios/AudioController.m
+++ b/ios/AudioController.m
@@ -26,12 +26,18 @@
 
 @implementation AudioController
 
-+ (instancetype) sharedInstance {
-  static AudioController *instance = nil;
-  if (!instance) {
-    instance = [[self alloc] init];
-  }
-  return instance;
+- (instancetype) initWithSampleRate:(double)specifiedSampleRate {
+    self = [super init];
+    if (self) {
+        _specifiedSampleRate = specifiedSampleRate;
+    }
+    return self;
+}
+
+- (OSStatus) recreateIOUnit {
+    AudioComponentInstanceDispose(remoteIOUnit);
+    audioComponentInitialized = NO;
+    return [self prepare];
 }
 
 - (void) dealloc {
@@ -121,13 +127,13 @@ static OSStatus playbackCallback(void *inRefCon,
   return status;
 }
 
-- (OSStatus) prepareWithSampleRate:(double) specifiedSampleRate {
+- (OSStatus) prepare {
   OSStatus status = noErr;
 
   AVAudioSession *session = [AVAudioSession sharedInstance];
 
   NSError *error;
-  BOOL ok = [session setCategory:AVAudioSessionCategoryRecord error:&error];
+  [session setCategory:AVAudioSessionCategoryRecord error:&error];
 
   // This doesn't seem to really indicate a problem (iPhone 6s Plus)
 #ifdef IGNORE
@@ -140,7 +146,7 @@ static OSStatus playbackCallback(void *inRefCon,
   [session setPreferredIOBufferDuration:10 error:&error];
 
   double sampleRate = session.sampleRate;
-  sampleRate = specifiedSampleRate;
+  sampleRate = self.specifiedSampleRate;
   if (!audioComponentInitialized) {
     audioComponentInitialized = YES;
     // Describe the RemoteIO unit
@@ -261,7 +267,7 @@ static OSStatus playbackCallback(void *inRefCon,
 }
 
 - (OSStatus) start {
-  return AudioOutputUnitStart(self->remoteIOUnit);
+    return AudioOutputUnitStart(self->remoteIOUnit);
 }
 
 - (OSStatus) stop {

--- a/ios/GoogleSpeechApi.m
+++ b/ios/GoogleSpeechApi.m
@@ -148,7 +148,7 @@ RCT_EXPORT_METHOD(stop) {
     }
     
     // We recommend sending samples in 100ms chunks
-    int chunk_size = 0.1 /* seconds/chunk */ * _sampleRate * 2 /* bytes/sample */ ; /* bytes/chunk */
+    int chunk_size = 0.1 /* seconds/chunk */ * self.sampleRate * 2 /* bytes/sample */ ; /* bytes/chunk */
     
     if ([self.audioData length] > chunk_size) {
         [[SpeechRecognitionService sharedInstance]
@@ -172,8 +172,7 @@ RCT_EXPORT_METHOD(stop) {
                     [self stopSpeech];
                 }
             }
-        }
-         ];
+        }];
         self.audioData = [[NSMutableData alloc] init];
     }
 }

--- a/ios/GoogleSpeechApi.m
+++ b/ios/GoogleSpeechApi.m
@@ -5,12 +5,13 @@
 
 #import "GoogleSpeechApi.h"
 
-@interface GoogleSpeechApi () <AVAudioRecorderDelegate, AVAudioPlayerDelegate, AudioControllerDelegate>
-@property (nonatomic, strong) AVAudioRecorder *audioRecorder;
+@interface GoogleSpeechApi () <AudioControllerDelegate>
+
 @property (nonatomic, strong) NSString *apiKey;
 @property (nonatomic, strong) NSMutableData *audioData;
 @property (nonatomic, strong) AudioController *audioController;
 @property (nonatomic, assign) double sampleRate;
+
 @end
 
 @implementation GoogleSpeechApi
@@ -59,12 +60,6 @@ RCT_EXPORT_METHOD(stop) {
 
 - (NSArray<NSString *>*)supportedEvents {
     return @[@"onSpeechRecognized", @"onSpeechRecognizedError", @"onStartError", @"onStopError"];
-}
-
-- (NSString *)soundFilePath {
-    NSArray *dirPaths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-    NSString *docsDir = dirPaths[0];
-    return [docsDir stringByAppendingPathComponent:@"sound.caf"];
 }
 
 #pragma mark - Private

--- a/ios/GoogleSpeechApi.m
+++ b/ios/GoogleSpeechApi.m
@@ -5,13 +5,12 @@
 
 #import "GoogleSpeechApi.h"
 
-#define SAMPLE_RATE 16000.0f
-
 @interface GoogleSpeechApi () <AVAudioRecorderDelegate, AVAudioPlayerDelegate, AudioControllerDelegate>
-@property (strong, nonatomic) AVAudioRecorder *audioRecorder;
-@property (strong, nonatomic) AVAudioSession *audioSession;
-@property (strong, nonatomic) NSString *apiKey;
+@property (nonatomic, strong) AVAudioRecorder *audioRecorder;
+@property (nonatomic, strong) NSString *apiKey;
 @property (nonatomic, strong) NSMutableData *audioData;
+@property (nonatomic, strong) AudioController *audioController;
+@property (nonatomic, assign) double sampleRate;
 @end
 
 @implementation GoogleSpeechApi
@@ -22,32 +21,44 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(setApiKey:(NSString *)apiKey) {
     _apiKey = apiKey;
+    [SpeechRecognitionService sharedInstance].apiKey = apiKey;
 }
 
 RCT_EXPORT_METHOD(start) {
-    [AudioController sharedInstance].delegate = self;
-    _audioSession = [AVAudioSession sharedInstance];
-    [_audioSession setCategory:AVAudioSessionCategoryRecord error:nil];
-    
-    _audioData = [[NSMutableData alloc] init];
-    [[AudioController sharedInstance] prepareWithSampleRate:SAMPLE_RATE];
-    [[SpeechRecognitionService sharedInstance] setSampleRate:SAMPLE_RATE];
-    [[SpeechRecognitionService sharedInstance] setApiKey:_apiKey];
-    [[AudioController sharedInstance] start];
+    [self startSpeech:false];
 }
 
 RCT_EXPORT_METHOD(stop) {
     [self stopSpeech];
 }
 
-#pragma mark -
+#pragma mark - Overwrites
+
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _sampleRate = 16000.0f;
+        [SpeechRecognitionService sharedInstance].sampleRate = _sampleRate;
+        _audioController = [[AudioController alloc] initWithSampleRate:_sampleRate];
+        OSStatus osStatus = [_audioController prepare];
+        NSError *error = [self errorForOSStatus:osStatus];
+        if (error) {
+            [self handleStartError:error];
+        }
+    }
+    return self;
+}
 
 - (dispatch_queue_t)methodQueue {
     return dispatch_get_main_queue();
 }
 
 - (NSArray<NSString *>*)supportedEvents {
-    return @[@"onSpeechRecognized", @"onSpeechRecognizedError"];
+    return @[@"onSpeechRecognized", @"onSpeechRecognizedError", @"onStartError", @"onStopError"];
 }
 
 - (NSString *)soundFilePath {
@@ -56,11 +67,81 @@ RCT_EXPORT_METHOD(stop) {
     return [docsDir stringByAppendingPathComponent:@"sound.caf"];
 }
 
-- (void)stopSpeech {
-    [[AudioController sharedInstance] stop];
-    [[SpeechRecognitionService sharedInstance] stopStreaming];
-    [_audioSession setCategory:AVAudioSessionCategoryPlayback error:nil];
+#pragma mark - Private
+
+- (void)startSpeech:(BOOL)isNewIOUnit {
+    self.audioController.delegate = self;
+    self.audioData = [[NSMutableData alloc] init];
+    
+    OSStatus osStatus = noErr;
+    NSError *error = nil;
+    if (![[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryRecord error:&error]) {
+        [self handleStartError:error];
+        [self stopSpeech];
+        return;
+    }
+    
+    osStatus = [self.audioController start];
+    error = [self errorForOSStatus:osStatus];
+    // Do not go further if there was no error during start.
+    if (!error) {
+        return;
+    }
+    
+    // Do not go further if there was an error during start new Remote IO Unit
+    if (isNewIOUnit) {
+        [self handleStartError:error];
+        [self stopSpeech];
+        return;
+    }
+    
+    // Otherwise recreate IOUnit.
+    osStatus = [self.audioController recreateIOUnit];
+    error = [self errorForOSStatus:osStatus];
+    
+    // Try once again to start speech if recreation of IOUnit succeded.
+    // Handle error otherwise.
+    if (!error) {
+        [self startSpeech:YES];
+    } else {
+        [self handleStartError:error];
+        [self stopSpeech];
+    }
 }
+
+- (void)stopSpeech {
+    [[SpeechRecognitionService sharedInstance] stopStreaming];
+    OSStatus osStatus = [self.audioController stop];
+    NSError *error = [self errorForOSStatus:osStatus];
+    if (error) {
+        [self handleStopError:error];
+    }
+    if (![[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:&error]) {
+        [self handleStopError:error];
+    }
+    self.audioController.delegate = nil;
+}
+
+- (NSError *)errorForOSStatus:(OSStatus)osStatus {
+    if (osStatus == 0) {
+        return nil;
+    }
+    return [NSError errorWithDomain:NSOSStatusErrorDomain code:osStatus userInfo:nil];
+}
+
+- (void)handleStopError:(NSError *)error {
+    [self sendError:error viaEventWithName:@"onStopError"];
+}
+
+- (void)handleStartError:(NSError *)error {
+    [self sendError:error viaEventWithName:@"onStartError"];
+}
+
+- (void)sendError:(NSError *)error viaEventWithName:(NSString *)eventName  {
+    [self sendEventWithName:eventName body:@{@"message": error.localizedDescription, @"code": @(error.code)}];
+}
+
+#pragma mark - AudioControllerDelegate
 
 - (void)processSampleData:(NSData *)data {
     [self.audioData appendData:data];
@@ -72,27 +153,31 @@ RCT_EXPORT_METHOD(stop) {
     }
     
     // We recommend sending samples in 100ms chunks
-    int chunk_size = 0.1 /* seconds/chunk */ * SAMPLE_RATE * 2 /* bytes/sample */ ; /* bytes/chunk */
+    int chunk_size = 0.1 /* seconds/chunk */ * _sampleRate * 2 /* bytes/sample */ ; /* bytes/chunk */
     
     if ([self.audioData length] > chunk_size) {
-        [[SpeechRecognitionService sharedInstance] streamAudioData:self.audioData
-                                                    withCompletion:^(StreamingRecognizeResponse *response, NSError *error) {
-                                                        if (error) {
-                                                            [self sendEventWithName:@"onSpeechRecognizedError" body:@{@"message": [error localizedDescription], @"isFinal":@(YES)}];
-                                                            [self stopSpeech];
-                                                        } else if (response) {
-                                                            BOOL finished = NO;
-                                                            for (StreamingRecognitionResult *result in response.resultsArray) {
-                                                                if (result.isFinal) {
-                                                                    finished = YES;
-                                                                }
-                                                            }
-                                                            [self sendEventWithName:@"onSpeechRecognized" body:@{@"text": response.resultsArray.firstObject.alternativesArray.firstObject.transcript, @"isFinal":@(finished)}];
-                                                            if (finished) {
-                                                                [self stopSpeech];
-                                                            }
-                                                        }
-                                                    }
+        [[SpeechRecognitionService sharedInstance]
+         streamAudioData:self.audioData
+         withCompletion:^(StreamingRecognizeResponse *response, NSError *error) {
+            if (error) {
+                [self sendEventWithName:@"onSpeechRecognizedError"
+                                   body:@{@"message": error.localizedDescription, @"isFinal":@(YES)}];
+                [self stopSpeech];
+            } else if (response) {
+                BOOL finished = NO;
+                for (StreamingRecognitionResult *result in response.resultsArray) {
+                    if (result.isFinal) {
+                        finished = YES;
+                    }
+                }
+                NSString *transcript = response.resultsArray.firstObject.alternativesArray.firstObject.transcript;
+                [self sendEventWithName:@"onSpeechRecognized"
+                                   body:@{@"text": transcript, @"isFinal":@(finished)}];
+                if (finished) {
+                    [self stopSpeech];
+                }
+            }
+        }
          ];
         self.audioData = [[NSMutableData alloc] init];
     }


### PR DESCRIPTION
This PR fixes following issues:
- crash in demo app caused by missing `NSMicrophoneUsageDescription` key in `Info.plist`
- format in readme.
- removed some unused code in `GoogleSpeechApi.m` class.
- non-working speech to text implementation after moving app to background and foreground again.
-  non-working speech to text implementation after running "hey Siri!". In this case entire RemoteIOUnit has to be recreated to work correctly (it was the simplest solution). So if any error appear when invoking `start` method, new implementation recreates RemoteIOUnit and tries to start speech to text again.
- added to more events: `onStartError` and `onStopError` which notifies RN app that something went wrong during speech start and stop. So far it only applies to iOS part.
- cleaned up implementation of `GoogleSpeechApi.m` (ordered methods, modern objective-c syntax, more readable indentation etc.)
- added `RCTDevLoadingView.h` to demo app's `AppDelegate` to silence warning which was cause by overwritten `GoogleSpeechApi.init` method.