### PR TITLE
Add speech context phrases support for iOS

### DIFF
--- a/ExampleApp/App.js
+++ b/ExampleApp/App.js
@@ -45,6 +45,9 @@ export default class App extends Component {
   componentDidMount(){
     AppState.addEventListener('change', this.onAppStateChange)
     GoogleSpeechApi.setApiKey("Your google access token")
+    if (Platform.OS === 'ios') {
+      GoogleSpeechApi.setSpeechContextPhrases(["weather"])
+    }
     EventEmitter.addListener('onSpeechRecognized', (event) => {
       var previousTexts = this.state.previousTexts;
       var currentText = event['text']

--- a/ios/GoogleSpeechApi.m
+++ b/ios/GoogleSpeechApi.m
@@ -7,7 +7,6 @@
 
 @interface GoogleSpeechApi () <AudioControllerDelegate>
 
-@property (nonatomic, strong) NSString *apiKey;
 @property (nonatomic, strong) NSMutableData *audioData;
 @property (nonatomic, strong) AudioController *audioController;
 @property (nonatomic, assign) double sampleRate;
@@ -21,8 +20,11 @@ RCT_EXPORT_MODULE()
 #pragma mark - EXPORT METHODS
 
 RCT_EXPORT_METHOD(setApiKey:(NSString *)apiKey) {
-    _apiKey = apiKey;
     [SpeechRecognitionService sharedInstance].apiKey = apiKey;
+}
+
+RCT_EXPORT_METHOD(setSpeechContextPhrases:(NSArray<NSString *> *)speechContextPhrases) {
+    [SpeechRecognitionService sharedInstance].speechContextPhrases = speechContextPhrases;
 }
 
 RCT_EXPORT_METHOD(start) {
@@ -156,7 +158,7 @@ RCT_EXPORT_METHOD(stop) {
          withCompletion:^(StreamingRecognizeResponse *response, NSError *error) {
             if (error) {
                 [self sendEventWithName:@"onSpeechRecognizedError"
-                                   body:@{@"message": error.localizedDescription, @"isFinal":@(YES)}];
+                                   body:@{@"message": error.localizedDescription, @"isFinal":@YES}];
                 [self stopSpeech];
             } else if (response) {
                 BOOL finished = NO;

--- a/ios/SpeechRecognitionService.h
+++ b/ios/SpeechRecognitionService.h
@@ -31,6 +31,7 @@ typedef void (^SpeechRecognitionCompletionHandler)(StreamingRecognizeResponse *o
 - (BOOL) isStreaming;
 
 @property (nonatomic, assign) double sampleRate;
-@property (nonatomic, assign) NSString* apiKey;
+@property (nonatomic, strong) NSString *apiKey;
+@property (nonatomic, strong) NSArray<NSString *> *speechContextPhrases;
 
 @end

--- a/ios/SpeechRecognitionService.m
+++ b/ios/SpeechRecognitionService.m
@@ -61,11 +61,11 @@
 
     [_call start];
     _streaming = YES;
-      
+
     // send an initial request message to configure the service
     SpeechContext *speechContext = [[SpeechContext alloc] init];
     [speechContext.phrasesArray addObjectsFromArray:self.speechContextPhrases];
-      
+
     RecognitionConfig *recognitionConfig = [RecognitionConfig message];
     recognitionConfig.encoding = RecognitionConfig_AudioEncoding_Linear16;
     recognitionConfig.sampleRateHertz = self.sampleRate;

--- a/ios/SpeechRecognitionService.m
+++ b/ios/SpeechRecognitionService.m
@@ -61,13 +61,17 @@
 
     [_call start];
     _streaming = YES;
-
+      
     // send an initial request message to configure the service
+    SpeechContext *speechContext = [[SpeechContext alloc] init];
+    [speechContext.phrasesArray addObjectsFromArray:self.speechContextPhrases];
+      
     RecognitionConfig *recognitionConfig = [RecognitionConfig message];
     recognitionConfig.encoding = RecognitionConfig_AudioEncoding_Linear16;
     recognitionConfig.sampleRateHertz = self.sampleRate;
     recognitionConfig.languageCode = @"en-US";
     recognitionConfig.maxAlternatives = 1;
+    [recognitionConfig.speechContextsArray addObject:speechContext];
 
     StreamingRecognitionConfig *streamingRecognitionConfig = [StreamingRecognitionConfig message];
     streamingRecognitionConfig.config = recognitionConfig;


### PR DESCRIPTION
This PR:

- removes redundant `GoogleSpeechApi. apiKey` property. Forward set apiKey directly to `SpeechRecognitionService`
- adds method for setting speech context phrases [iOS only] - `GoogleSpeechApi.setSpeechContextPhrases`
- fixes wrong SpeechRecognitionService.apiKey property attributed (changed from assign to strong)